### PR TITLE
Use multivarious concat_pre_processors

### DIFF
--- a/R/bamfa.R
+++ b/R/bamfa.R
@@ -8,7 +8,7 @@
 #' @importFrom MASS ginv
 #' @importFrom crayon bold magenta green blue yellow
 #' @importFrom purrr map map2
-#' @importFrom multivarious init_transform prep fresh center
+#' @importFrom multivarious init_transform prep fresh center concat_pre_processors
 #' @importFrom multidesign multiblock
 NULL
 
@@ -493,10 +493,7 @@ bamfa.multiblock <- function(data, k_g = 2, k_l = 2, niter = 10, preproc = cente
   # Create concatenated preprocessor
   final_preproc <- NULL
   if (!is.null(proclist)) {
-       if (!exists("concat_pre_processors", mode = "function")) {
-          stop("Function 'concat_pre_processors' not found. Ensure multivarious package is loaded correctly.", call.=FALSE)
-      }
-      final_preproc <- concat_pre_processors(proclist, block_indices)
+      final_preproc <- multivarious::concat_pre_processors(proclist, block_indices)
   } else {
       # Should not happen if default preproc=center() was used, but handle defensively
       pass_proc <- multivarious::prep(multivarious::pass())

--- a/R/penalized_mfa.R
+++ b/R/penalized_mfa.R
@@ -42,7 +42,7 @@ adam_update_block <- function(V, G, M, V2, step_count,
 #' @importFrom chk chk_numeric chk_list chk_integer chk_gte chk_lte chk_flag
 #' @importFrom stats svd qr qr.Q qr.R
 #' @importFrom purrr map
-#' @importFrom multivarious fresh prep init_transform center
+#' @importFrom multivarious fresh prep init_transform center concat_pre_processors
 #' @importFrom dplyr pull select
 #' @importFrom rlang enquo
 NULL
@@ -605,11 +605,7 @@ penalized_mfa.list <- function(data,
   # Create the final preprocessor using concat_pre_processors
   final_preproc <- NULL
   if (!is.null(proclist)) {
-      # Ensure concat_pre_processors is available
-      if (!exists("concat_pre_processors", mode = "function")) {
-          stop("Function 'concat_pre_processors' not found. Ensure multivarious package is loaded correctly.", call.=FALSE)
-      }
-      final_preproc <- concat_pre_processors(proclist, block_indices)
+      final_preproc <- multivarious::concat_pre_processors(proclist, block_indices)
   } else {
       # Create a pass() preprocessor if no preprocessing was done
       # Need to ensure it's a finalized pre_processor object


### PR DESCRIPTION
## Summary
- add `@importFrom multivarious concat_pre_processors`
- call `multivarious::concat_pre_processors` directly instead of checking with `exists`

## Testing
- `R -q -e "library(testthat); test_dir('tests/testthat')"` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68488749e518832d99ec82c2955da635