### PR TITLE
Remove unused dimension tracking code

### DIFF
--- a/R/bamfa.R
+++ b/R/bamfa.R
@@ -271,14 +271,11 @@ bamfa.multiblock <- function(data, k_g = 2, k_l = 2, niter = 10, preproc = cente
   # Apply preprocessing to each block
   Xp <- vector("list", length(data))
   names(Xp) <- names(data)
-  X_dims <- vector("list", length(data))
-  names(X_dims) <- names(data)
   
   for (i in seq_along(data)) {
     Xi <- data[[i]]
     p <- proclist[[i]]
     Xp[[i]] <- multivarious::init_transform(p, Xi)
-    X_dims[[i]] <- dim(Xp[[i]])
   }
   
   # -----------------------------------------------------------------------

--- a/repomix-output.xml
+++ b/repomix-output.xml
@@ -803,14 +803,11 @@ bamfa.multiblock <- function(data, k_g = 2, k_l = 2, niter = 10, preproc = cente
   # Apply preprocessing to each block
   Xp <- vector("list", length(data))
   names(Xp) <- names(data)
-  X_dims <- vector("list", length(data))
-  names(X_dims) <- names(data)
   
   for (i in seq_along(data)) {
     Xi <- data[[i]]
     p <- proclist[[i]]
     Xp[[i]] <- multivarious::init_transform(p, Xi)
-    X_dims[[i]] <- dim(Xp[[i]])
   }
   
   # -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove `X_dims` variable and associated preprocessing logic
- update example XML output to reflect the change

## Testing
- `Rscript -e 'library(testthat); test_dir("tests/testthat")'` *(fails: Rscript not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848874d2c68832d902cd5bf531e2ea8