### PR TITLE
Fix subject splitting in bada.multidesign

### DIFF
--- a/R/bada.R
+++ b/R/bada.R
@@ -151,7 +151,7 @@ bada.multidesign <- function(data, y, subject, preproc=center(), ncomp=2,
 
   
   ## data split by subject
-  sdat <- split(data, subject)
+  sdat <- multidesign::split(data, !!subject_quo)
   
   
   ## pre-processors, one per subject

--- a/tests/testthat/test-bada-multidesign.R
+++ b/tests/testthat/test-bada-multidesign.R
@@ -1,0 +1,19 @@
+library(testthat)
+library(musca)
+
+skip_if_not_installed("multidesign")
+
+# basic splitting test for bada.multidesign
+
+set.seed(123)
+x <- matrix(rnorm(20), nrow = 10)
+design <- data.frame(
+  subj_id = rep(c("S1", "S2"), each = 5),
+  y = rep(c("A", "B"), 5)
+)
+md <- multidesign::multidesign(x, design)
+
+res <- bada(md, y = y, subject = subj_id, ncomp = 1)
+
+expect_equal(levels(res$subjects), c("S1", "S2"))
+


### PR DESCRIPTION
## Summary
- use `multidesign::split()` inside `bada.multidesign`
- add regression test for splitting by the selected subject variable

## Testing
- `R --version` *(fails: command not found)*
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488a3f1b90832d853cab7ffd876463