### PR TITLE
Add preprocessing and covariate projection tests

### DIFF
--- a/tests/testthat/test-preproc-utils.R
+++ b/tests/testthat/test-preproc-utils.R
@@ -1,0 +1,32 @@
+library(testthat)
+library(musca)
+
+# Basic matrices for preprocessing tests
+mat1 <- matrix(rnorm(20), nrow = 5)
+mat2 <- matrix(rnorm(30), nrow = 5)
+
+test_that("single preprocessor is replicated across blocks", {
+  prep_def <- multivarious::center()
+  res <- musca:::prepare_block_preprocessors(list(mat1, mat2), prep_def)
+  expect_length(res$proclist, 2)
+  expect_true(all(vapply(res$proclist, inherits, logical(1), "pre_processor")))
+  expect_equal(lapply(res$Xp, ncol), list(ncol(mat1), ncol(mat2)))
+})
+
+
+
+test_that("list preprocessor length mismatch errors", {
+  prep_list <- list(multivarious::center())
+  expect_error(
+    musca:::prepare_block_preprocessors(list(mat1, mat2), prep_list),
+    "length"  # message about length mismatch
+  )
+})
+
+test_that("inconsistent column counts warn when no preprocessing", {
+  expect_warning(
+    musca:::prepare_block_preprocessors(list(mat1, mat2[,1:3]), NULL),
+    "Input blocks"
+  )
+})
+

--- a/tests/testthat/test-project-covariate.R
+++ b/tests/testthat/test-project-covariate.R
@@ -1,0 +1,29 @@
+library(testthat)
+library(musca)
+
+set.seed(42)
+# create a simple set of covariance matrices
+gen_cov <- function(seed) {
+  set.seed(seed)
+  M <- matrix(rnorm(16), 4, 4)
+  tcrossprod(M) / 4
+}
+subject_data <- lapply(1:5, gen_cov)
+res <- covstatis(subject_data, ncomp = 2, norm_method = "none", dcenter = FALSE)
+
+covar <- rnorm(5)
+
+test_that("dimension mode returns named numeric vector", {
+  dim_cos <- project_covariate(res, covar, what = "dimension", scale = "cosine")
+  expect_type(dim_cos, "double")
+  expect_length(dim_cos, 2)
+  expect_equal(names(dim_cos), c("Dim1", "Dim2"))
+  expect_true(all(abs(dim_cos) <= 1))
+})
+
+test_that("observation mode returns matrix with labels", {
+  roi_beta <- project_covariate(res, covar, what = "observation", scale = "beta")
+  expect_equal(dim(roi_beta), c(4, 2))
+  expect_equal(rownames(roi_beta), res$labels)
+  expect_equal(colnames(roi_beta), c("Dim1", "Dim2"))
+})


### PR DESCRIPTION
## Summary
- add tests for prepare_block_preprocessors utility
- add tests for project_covariate() for covstatis objects

## Testing
- `R -q -e 'library(testthat); test_dir("tests/testthat")'` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684892fafd84832da37cd822a0e49f4a