### PR TITLE
Add coverage tests for utilities

### DIFF
--- a/tests/testthat/test-synthdat.R
+++ b/tests/testthat/test-synthdat.R
@@ -1,0 +1,23 @@
+library(testthat)
+library(musca)
+
+# Tests for synthetic_multiblock
+
+set.seed(1)
+res <- synthetic_multiblock(S = 3, n = 10, p = 5, r = 2, sigma = 0, sphere = FALSE)
+
+# check basic structure
+expect_equal(length(res$data_list), 3)
+expect_null(res$coords_list)
+expect_equal(dim(res$F_true), c(10,2))
+
+# data matrices should equal F_true %*% t(V_true[[i]]) when sigma=0
+for(i in 1:3) {
+  expect_equal(dim(res$V_true[[i]]), c(5,2))
+  expect_equal(res$data_list[[i]], res$F_true %*% t(res$V_true[[i]]))
+  expect_equal(colMeans(res$data_list[[i]]), rep(0,5))
+  expect_equal(crossprod(res$V_true[[i]]), diag(2), tolerance = 1e-12)
+}
+
+# orthonormality of shared factors
+expect_equal(crossprod(res$F_true), diag(2), tolerance = 1e-12)

--- a/tests/testthat/test-utils-misc.R
+++ b/tests/testthat/test-utils-misc.R
@@ -1,0 +1,26 @@
+library(testthat)
+library(musca)
+
+# Tests for %||% operator
+expect_equal(NULL %||% 5, 5)
+expect_equal(3 %||% 4, 3)
+
+# Tests for adam_update_block
+set.seed(1)
+V <- matrix(rnorm(4),2,2)
+G <- matrix(rnorm(4),2,2)
+M <- matrix(0,2,2)
+V2 <- matrix(0,2,2)
+res <- musca:::adam_update_block(V,G,M,V2,step_count=1,beta1=0.9,beta2=0.999,adam_epsilon=1e-8,learning_rate=0.01)
+
+# manual computation
+exp_M <- 0.1*G
+exp_V2 <- 0.001*(G*G)
+M_hat <- exp_M / (1 - 0.9)
+V_hat <- exp_V2 / (1 - 0.999)
+step <- 0.01 * M_hat / (sqrt(V_hat) + 1e-8)
+exp_V_new <- V - step
+
+expect_equal(res$M, exp_M)
+expect_equal(res$V2, exp_V2)
+expect_equal(res$V, exp_V_new)


### PR DESCRIPTION
## Summary
- add tests for `synthetic_multiblock`
- add tests for `%||%` and `adam_update_block`

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848d7c37d8c832d9a4ea1052456ef94